### PR TITLE
Support for authentication in redis connection

### DIFF
--- a/pushd.coffee
+++ b/pushd.coffee
@@ -12,6 +12,9 @@ PushServices = require('./lib/pushservices').PushServices
 Payload = require('./lib/payload').Payload
 logger = console
 
+if settings.server?.redis_auth?
+    redis.auth(settings.server.redis_auth)
+
 createSubscriber = (fields, cb) ->
     throw new Error("Invalid value for `proto'") unless service = pushServices.getService(fields.proto)
     throw new Error("Invalid value for `token'") unless fields.token = service.validateToken(fields.token)

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -2,6 +2,7 @@ exports.server =
     redis_socket: '/var/run/redis/redis.sock'
     # redis_port: 6379
     # redis_host: 'localhost'
+    # redis_auth: 'password'
     tcp_port: 80
     udp_port: 80
     access_log: yes


### PR DESCRIPTION
I need to authenticate to a remote redis service, it would be useful if this rather simple change could be merged.
