### PR TITLE
Make listening on UDP port optional

### DIFF
--- a/pushd.coffee
+++ b/pushd.coffee
@@ -86,7 +86,7 @@ if eventSourceEnabled
 
 port = settings?.server?.tcp_port ? 80
 app.listen port
-logger.log "Listening on port #{port}"
+logger.log "Listening on tcp port #{port}"
 
 
 # UDP Event API
@@ -119,4 +119,7 @@ udpApi.on 'message', (msg, rinfo) ->
                     return
             logger.log("UDP/#{method} #{req.pathname} #{status}") if settings.server?.access_log
 
-udpApi.bind settings?.server?.udp_port ? 80
+port = settings?.server?.udp_port
+if port?
+    udpApi.bind port
+    logger.log "Listening on udp port #{port}"


### PR DESCRIPTION
I am planning to run pushd on a somewhat public server using IP filtering.

TCP itself is somewhat vulnerable to MITM attacks, therefore source IP is not a very reliable authorization. However, I do not consider TCP to be an issue at this point. The UDP handler of pushd on the other hand is receive-only, which means the server never even tries to contact the sender to prove if the packet was valid or not.

Therefore for security reasons I would like to disable UDP handling for now, it doesn't bring any extra benefits to me because all the functionality is available through the REST API as well. I might consider some simple HTTP authentication scheme later on, but for now this should be enough to get things running.
