### PR TITLE
Fix sending broadcast events, add a unit test respectively

### DIFF
--- a/lib/event.coffee
+++ b/lib/event.coffee
@@ -68,7 +68,7 @@ class Event
                 return (done) =>
                     action(new Subscriber(@redis, subscriberId), options, done)
 
-        subscribersKey = if @name is 'boardcast' then 'subscribers' else "#{@key}:subs"
+        subscribersKey = if @name is 'broadcast' then 'subscribers' else "#{@key}:subs"
         page = 0
         perPage = 100
         total = 0


### PR DESCRIPTION
Broadcast events did not work, and it seemed to be because of a typo. Fixed the problem and added a test that makes sure broadcast events are sent to subscribers that are not subscribed to any events.
