### PR TITLE
Update node and node-apn dependencies in order to make apns work again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "engines":
     {
-        "node": "~0.8.19"
+        "node": "~0.10.4"
     },
     "dependencies":
     {


### PR DESCRIPTION
The node-apn v1.3.0 was broken if no conf.feedback was set, this was fixed in upstream v1.3.1. Also since v1.3.0 node-apn seems to use EventEmitter.listenerCount which is not available on node 0.8.x, updating to node 0.10.x helped. Version 0.10.4 used, since it ran all tests correctly on a local machine, some more testing might be necessary.
