### PR TITLE
Bugfix in GCM handler, multicastResult was always null

### DIFF
--- a/lib/pushservices/gcm.coffee
+++ b/lib/pushservices/gcm.coffee
@@ -41,7 +41,7 @@ class PushServiceGCM
         delete @multicastQueue[messageKey]
         clearTimeout message.timeoutId
 
-        @driver.send message.note, message.tokens, 4, (multicastResult) =>
+        @driver.send message.note, message.tokens, 4, (err, multicastResult) =>
             if not multicastResult?
                 @logger?.error("GCM Error: empty response")
             else if 'results' of multicastResult


### PR DESCRIPTION
Because of the missing parameter, multicastResult was not processed
correctly
