### PR TITLE
Close HTTP request

### DIFF
--- a/lib/pushservices/http.coffee
+++ b/lib/pushservices/http.coffee
@@ -31,5 +31,6 @@ class PushServiceHTTP
                 #subscriber.delete()
 
             req.write(JSON.stringify(body))
+            req.end()
 
 exports.PushServiceHTTP = PushServiceHTTP


### PR DESCRIPTION
A minor bug fix for HTTP push service: close HTTP request to avoid leaking resources
