### PR TITLE
Check for null in the bulk subscription edit

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -83,6 +83,11 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
                 return
 
         req.subscriber.getSubscriptions (subs) ->
+            if not subs?
+                logger.error "No subscriber #{req.subscriber.id}"
+                res.send 404
+                return
+
             tasks = []
 
             for sub in subs


### PR DESCRIPTION
The bulk edit was throwing an exception if the subscriber ID was invalid because it tried to access properties of null object.
