### PR TITLE
Support raw notifications in MPNS as JSON.

### DIFF
--- a/lib/pushservices/mpns.coffee
+++ b/lib/pushservices/mpns.coffee
@@ -14,9 +14,9 @@ class PushServiceMPNS
     push: (subscriber, subOptions, payload) ->
         subscriber.get (info) =>
             note = {}
-            if subOptions?.ignore_message isnt true
-                switch @conf.type
-                    when "toast"
+            switch @conf.type
+                when "toast"
+                    if subOptions?.ignore_message isnt true
                         sender = mpns.sendToast
                         note.text1 = payload.localizedTitle(info.lang)
                         note.text2 = payload.localizedMessage(info.lang)
@@ -27,27 +27,34 @@ class PushServiceMPNS
                                 @logger.error("Cannot compile MPNS param template: #{e}")
                                 return
 
-                    when "tile" # live tile under WP 7.5 or flip tile under WP 8.0+
-                        map = @conf.tileMapping
-                        properties = ["id", "title", "count", "backgroundImage", "backBackgroundImage", "backTitle", "backContent"]
-                        if info.version >= 8.0
-                            sender = mpns.sendFlipTile
-                            properties.push(["smallBackgroundImage", "wideBackgroundImage", "wideBackContent", "wideBackBackgroundImage"]...)
-                        else
-                            sender = mpns.sendTile
-                        for property in properties
-                            if map[property]
-                                try
-                                    note[property] = payload.compileTemplate(map[property])
-                                catch e
-                                    # ignore this property
-
+                when "tile" # live tile under WP 7.5 or flip tile under WP 8.0+
+                    map = @conf.tileMapping
+                    properties = ["id", "title", "count", "backgroundImage", "backBackgroundImage", "backTitle", "backContent"]
+                    if info.version >= 8.0
+                        sender = mpns.sendFlipTile
+                        properties.push(["smallBackgroundImage", "wideBackgroundImage", "wideBackContent", "wideBackBackgroundImage"]...)
                     else
-                        @logger?.error("Unsupported MPNS notification type: #{@conf.type}")
+                        sender = mpns.sendTile
+                    for property in properties
+                        if map[property]
+                            try
+                                note[property] = payload.compileTemplate(map[property])
+                            catch e
+                                # ignore this property
 
-            else
-                sender = mpns.sendRaw
-                note[key] = value for key, value of payload.data
+                when "raw"
+                    sender = mpns.sendRaw
+                    if subOptions?.ignore_message isnt true
+                        if title = payload.localizedTitle(info.lang)
+                            note['title'] = title
+                        if message = payload.localizedMessage(info.lang)
+                            note['message'] = message
+                    note[key] = value for key, value of payload.data
+                    # The driver only accepts payload string in raw mode
+                    note = { payload: JSON.stringify(payload.data) }
+
+                else
+                    @logger?.error("Unsupported MPNS notification type: #{@conf.type}")
 
             if sender
                 sender info.token, note, (error, result) =>

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -53,11 +53,6 @@ exports['gcm'] =
     class: require('./lib/pushservices/gcm').PushServiceGCM
     key: 'GCM API KEY HERE'
 
-exports['mpns'] =
-    enabled: no
-    class: require('./lib/pushservices/mpns').PushServiceMPNS
-    endpoint: 'http://sn1.notify.live.net/throttledthirdparty/01.00/YOUR_ENDPOINT_HERE'
-
 # # Legacy Android Push Service
 # exports['c2dm'] =
 #     enabled: yes
@@ -99,3 +94,8 @@ exports['mpns-tile'] =
         wideBackgroundImage: "${data.wide_background_image_url}"
         wideBackContent: "${data.message}"
         wideBackBackgroundImage: "#005e8a"
+
+exports['mpns-raw'] =
+    enabled: yes
+    class: require('./lib/pushservices/mpns').PushServiceMPNS
+    type: 'raw'


### PR DESCRIPTION
NOTE! This affects existing clients if they have set ignore_message.

Earlier the MPNS functionality was as follows:
1. Send toast notification only if ignore_message is NOT true
2. Send tile notification only if ignore_message is NOT true
3. Send raw notification only if ignore_message is true, send only data.payload as string

This patch changes the functionality to the following:
1. Send toast notification only if ignore_message is NOT true
2. Send tile notification always, do not care about ignore_message
3. Send raw notification always as JSON, containing all data.<key> values
4. If ignore_message is NOT true, include title and message keys in the raw JSON data

The motivation behind this change is that the toast notification is basically the original message of iOS that ignore_message was meant to filter. The tile notification is closer to the badge updating of iOS (count value is basically the same), so ignore_message shouldn't filter it out. And the raw message is basically equivalent to the whole data sent to iOS/Android.

JSON format was simply chosen, because it is the most natural format for this service. Microsoft doesn't define any data format for raw notifications, although they use XML in their example.
