### PR TITLE
Make badge increment optional (defaults to true)

### DIFF
--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -12,6 +12,7 @@ class Payload
         @msg = {}
         @data = {}
         @var = {}
+        @incrementBadge = yes
 
         # Read fields
         for own key, value of data
@@ -24,6 +25,7 @@ class Payload
                 when 'title' then @title.default = value
                 when 'msg' then @msg.default = value
                 when 'sound' then @sound = value
+                when 'incrementBadge' then @incrementBadge = value != 'false'
                 else
                     if ([prefix, subkey] = key.split('.', 2)).length is 2
                         @[prefix][subkey] = value

--- a/lib/pushservices/apns.coffee
+++ b/lib/pushservices/apns.coffee
@@ -31,7 +31,12 @@ class PushServiceAPNS
             device.subscriberId = subscriber.id # used for error logging
             if subOptions?.ignore_message isnt true and alert = payload.localizedMessage(info.lang)
                 note.alert = alert
-            note.badge = badge if not isNaN(badge = parseInt(info.badge) + 1)
+
+            badge = parseInt(info.badge)
+            if payload.incrementBadge
+                badge += 1
+
+            note.badge = badge if not isNaN(badge)
             note.sound = payload.sound
             if @payloadFilter?
                 for key, val of payload.data
@@ -40,6 +45,7 @@ class PushServiceAPNS
                 note.payload = payload.data
             @driver.pushNotification note, device
             # On iOS we have to maintain the badge counter on the server
-            subscriber.incr 'badge'
+            if payload.incrementBadge
+                subscriber.incr 'badge'
 
 exports.PushServiceAPNS = PushServiceAPNS


### PR DESCRIPTION
Sometimes I don't want the badge to increment on iOS.
I added an optional parameter to the payload (used by event API to publish an event).
