### PR TITLE
More flexible logging configuration

### DIFF
--- a/pushd.coffee
+++ b/pushd.coffee
@@ -16,9 +16,14 @@ if settings.server.redis_socket?
 else if settings.server.redis_port? or settings.server.redis_host?
     redis = require('redis').createClient(settings.server.redis_port, settings.server.redis_host)
 
-if settings.loglevel?
-    logger.remove(logger.transports.Console);
-    logger.add(logger.transports.Console, { level: settings.loglevel });
+if settings.logging?
+    logger.remove(logger.transports.Console)
+    for loggerconfig in settings.logging
+        transport = logger.transports[loggerconfig['transport']]
+        if transport?
+            logger.add(transport, loggerconfig.options || {})
+        else
+            process.stderr.write "Invalid logger transport: #{loggerconfig['transport']}\n"
 
 if settings.server?.redis_auth?
     redis.auth(settings.server.redis_auth)

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -99,3 +99,21 @@ exports['mpns-raw'] =
     enabled: yes
     class: require('./lib/pushservices/mpns').PushServiceMPNS
     type: 'raw'
+
+# Transports: Console, File, Http
+# 
+# Common options:
+# level:
+#   error: log errors only
+#   warn: log also warnings
+#   info: log status messages
+#   verbose: log event and subscriber creation and deletion
+#   silly: log submitted message content
+#
+# See https://github.com/flatiron/winston#working-with-transports for
+# other transport-specific options.
+exports['logging'] = [
+        transport: 'Console'
+        options:
+            level: 'info'
+    ]


### PR DESCRIPTION
Allows, for example, redirecting logs to a file instead of the console.
This change breaks settings.loglevel option (which is now ignored), but it was not documented in settings-sample.coffee earlier. If you think this is not a good idea then the patch can be modified to support both configurations, but that would not be so maintainable in the future.
