### PR TITLE
Update middlewares to work on the specified express without warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "mpns": "2.1.0",
         "async": "~0.2.5",
         "express": "~3.16.8",
+        "body-parser": "~1.9.0",
         "hiredis": "~0.1.17",
         "redis": "~0.12.1",
         "netmask": "~1.0.4",

--- a/pushd.coffee
+++ b/pushd.coffee
@@ -1,4 +1,5 @@
 express = require 'express'
+bodyParser = require 'body-parser'
 dgram = require 'dgram'
 zlib = require 'zlib'
 url = require 'url'
@@ -61,14 +62,13 @@ checkUserAndPassword = (username, password) =>
 
 app = express()
 
-app.configure ->
-    app.use(express.logger(':method :url :status')) if settings.server?.access_log
-    app.use(express.limit('1mb')) # limit posted data to 1MB
-    if settings.server?.auth? and not settings.server?.acl?
-        app.use(express.basicAuth checkUserAndPassword)
-    app.use(express.bodyParser())
-    app.use(app.router)
-    app.disable('x-powered-by');
+app.use(express.logger(':method :url :status')) if settings.server?.access_log
+if settings.server?.auth? and not settings.server?.acl?
+    app.use(express.basicAuth checkUserAndPassword)
+app.use(bodyParser.urlencoded({ limit: '1mb', extended: true }))
+app.use(bodyParser.json({ limit: '1mb' }))
+app.use(app.router)
+app.disable('x-powered-by');
 
 app.param 'subscriber_id', (req, res, next, id) ->
     try


### PR DESCRIPTION
With the current express pushd gives a lot of deprecated warnings, these changes should result in an identical behavior but with no warnings.
