### PR TITLE
New API endpoint GET /events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,21 @@ To get statistics from an event, perform a GET on `/event/EVENT_NAME`:
 - `200` Statistics returned
 - `404` The specified event does not exist
 
+#### List of registered events
+
+To get the names of currently registered events, perform a GET on `/events`:
+
+    > GET /events HTTP/1.1
+    >
+    ---
+    < HTTP/1.1 200 Ok
+    < Content-Type: application/json
+    <
+    < {"events": [
+    <   "EVENT_NAME1",
+    <   "EVENT_NAME2"
+    < ]}
+
 #### Event Purge
 
 When the application data provider know about a particular event will no longer be available, it can force pushd to forget about it and unsubscribe all current subscribers from it. To purge an event, perform a DELETE on `/event/EVENT_NAME`

--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -7,7 +7,7 @@ filterFields = (params) ->
     fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version']
     return fields
 
-exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher) ->
+exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, listEvents, eventPublisher) ->
     authorize ?= (realm) ->
 
     # subscriber registration
@@ -171,3 +171,9 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
                 res.send 204
             else
                 res.send 404
+
+    # List of registered events
+    app.get '/events', authorize('publish'), (req, res) ->
+        listEvents (events) ->
+            logger.verbose "Events: " + JSON.stringify events
+            res.json { events: events }, 200

--- a/lib/event.coffee
+++ b/lib/event.coffee
@@ -5,6 +5,10 @@ class Event
     OPTION_IGNORE_MESSAGE: 1
     name_format: /^[a-zA-Z0-9@:._-]{1,100}$/
 
+    listEvents: (redis, cb) ->
+        redis.smembers 'events', (err, values) ->
+            cb(values) if cb
+
     constructor: (@redis, @name) ->
         throw new Error("Missing redis connection") if not redis?
         throw new Error('Invalid event name ' + @name) if not Event::name_format.test @name

--- a/pushd.coffee
+++ b/pushd.coffee
@@ -123,7 +123,10 @@ authorize = (realm) ->
     else
         return (req, res, next) -> next()
 
-require('./lib/api').setupRestApi(app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher)
+listEvents = (cb) ->
+    Event::listEvents(redis, cb)
+
+require('./lib/api').setupRestApi(app, createSubscriber, getEventFromId, authorize, testSubscriber, listEvents, eventPublisher)
 if eventSourceEnabled
     require('./lib/eventsource').setup(app, authorize, eventPublisher)
 


### PR DESCRIPTION
Returns the names of all currently registered events. Since events are registered by the clients, it might be useful for the server to be able to list all currently registered events if they are not known beforehand.
