### PR TITLE
New API endpoint GET /subscriber-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,20 @@ To unsubscribe from an event, perform a DELETE on the subscription URL.
 - `400` Invalid subscriber id or event name format
 - `404` The specified subscriber does not exist
 
+#### List subscribers
+
+To get the number of active subscribers, perform a GET on `/subscriber-count`. Note that there might be more active subscribers than applications because of duplicate subscriptions.
+
+    > GET /subscriber-count HTTP/1.1
+    >
+    ---
+    < HTTP/1.1 200 OK
+    < Content-Type: application/json; charset=utf-8
+    <
+    < {
+    <   "count": 4
+    < }
+
 #### List subscribers’ Subscriptions
 
 To get the list of events a subscriber is subscribed to, perform a GET on `/subscriber/SUBSCRIBER_ID/subscriptions`.

--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -7,8 +7,14 @@ filterFields = (params) ->
     fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version']
     return fields
 
-exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher) ->
+exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher, countSubscribers) ->
     authorize ?= (realm) ->
+
+    # get number of subscribers
+    app.get '/subscriber-count', authorize('register'), (req, res) ->
+        countSubscribers (count) ->
+            logger.verbose "SubscribeCount: " + JSON.stringify count
+            res.json { count: count }, 200
 
     # subscriber registration
     app.post '/subscribers', authorize('register'), (req, res) ->

--- a/lib/subscriber.coffee
+++ b/lib/subscriber.coffee
@@ -258,5 +258,8 @@ class Subscriber
                 else
                     cb(null) if cb # null if subscriber doesn't exist
 
+    countSubscribers: (redis, cb) ->
+        redis.zcard "subscribers", (err, value) ->
+            cb(value) if cb
 
 exports.Subscriber = Subscriber

--- a/pushd.coffee
+++ b/pushd.coffee
@@ -123,7 +123,10 @@ authorize = (realm) ->
     else
         return (req, res, next) -> next()
 
-require('./lib/api').setupRestApi(app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher)
+countSubscribers = (cb) ->
+    Subscriber::countSubscribers(redis, cb)
+
+require('./lib/api').setupRestApi(app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher, countSubscribers)
 if eventSourceEnabled
     require('./lib/eventsource').setup(app, authorize, eventPublisher)
 


### PR DESCRIPTION
Returns the count of subscriptions as JSON. This does not need anything extra information added in redis to work like the earlier /stats endpoint: https://github.com/rs/pushd/pull/30
