### PR TITLE
Support for category and 'content-available' of apns payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Subscriber registration is performed through a HTTP REST API (see later for more
            -d token=FE66489F304DC75B8D6E8200DFF8A456E8DAEACEC428B427E9518741C92C6660 \
            -d lang=fr \
            -d badge=0 \
+           -d category=show \
+           -d contentAvailable=true \
            http://localhost/subscribers
 
 In reply, we get the following JSON structure:
@@ -209,6 +211,8 @@ Register a subscriber by POSTing on `/subscribers` with some subscriber informat
 
 - `lang`: The language code for the of the subscriber. This parameter is used to determine which message translation to use when pushing text notifications. You may use the 2 chars ISO code or a complete locale code (i.e.: en_CA) or any value you want as long as you provide the same values in your events. See below for info about events formatting.
 - `badge`: The current app badge value. This parameter is only applicable to iOS for which badge counters must be maintained server side. On iOS, when a user read or loads more unread items, you must inform the server of the badge's new value. This badge value will be incremented automatically by pushd each time a new notification is sent to the subscriber.
+- `category`: The category for the push notification action. This parameter is only applicable to iOS8. 
+- `contentAvailable`: The 'content-available' flag value. This parameter is only applicable to iOS7 and applications which support Silent Remote Notifications or Newsstand capability. With iOS7 it is possible to have the application wake up before the user opens the app.
 - `version`: This is the OS subscriber version. This parameter is only needed by Windows Phone OS. By setting this value to 7.5 or greater an `mpns` subscriber ids will enable new MPNS push features.
 
 ##### Return Codes
@@ -516,7 +520,7 @@ Testing
 
 ### Unit tests
 
-`npm tests`
+`npm test`
 
 ### Performance testing
 

--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -4,7 +4,7 @@ logger = require 'winston'
 
 filterFields = (params) ->
     fields = {}
-    fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version', 'category','contentAvailable']
+    fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version', 'category', 'contentAvailable']
     return fields
 
 exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher) ->

--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -4,7 +4,7 @@ logger = require 'winston'
 
 filterFields = (params) ->
     fields = {}
-    fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version']
+    fields[key] = val for own key, val of params when key in ['proto', 'token', 'lang', 'badge', 'version', 'category','contentAvailable']
     return fields
 
 exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSubscriber, eventPublisher) ->

--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -13,7 +13,6 @@ class Payload
         @data = {}
         @var = {}
         @incrementBadge = yes
-        @contentAvailable = false
 
         # Read fields
         for own key, value of data

--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -13,6 +13,8 @@ class Payload
         @data = {}
         @var = {}
         @incrementBadge = yes
+        @category = {}
+        @contentAvalilable = false
 
         # Read fields
         for own key, value of data
@@ -26,6 +28,8 @@ class Payload
                 when 'msg' then @msg.default = value
                 when 'sound' then @sound = value
                 when 'incrementBadge' then @incrementBadge = value != 'false'
+                when 'category' then @category = value
+                when 'contentAvalilable' then @contentAvalilable = value != 'false'
                 else
                     if ([prefix, subkey] = key.split('.', 2)).length is 2
                         @[prefix][subkey] = value

--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -13,7 +13,6 @@ class Payload
         @data = {}
         @var = {}
         @incrementBadge = yes
-        @category = {}
         @contentAvailable = false
 
         # Read fields

--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -14,7 +14,7 @@ class Payload
         @var = {}
         @incrementBadge = yes
         @category = {}
-        @contentAvalilable = false
+        @contentAvailable = false
 
         # Read fields
         for own key, value of data
@@ -29,7 +29,7 @@ class Payload
                 when 'sound' then @sound = value
                 when 'incrementBadge' then @incrementBadge = value != 'false'
                 when 'category' then @category = value
-                when 'contentAvalilable' then @contentAvalilable = value != 'false'
+                when 'contentAvailable' then @contentAvailable = value != 'false'
                 else
                     if ([prefix, subkey] = key.split('.', 2)).length is 2
                         @[prefix][subkey] = value

--- a/lib/pushservices/apns.coffee
+++ b/lib/pushservices/apns.coffee
@@ -39,6 +39,8 @@ class PushServiceAPNS
 
             note.badge = badge if not isNaN(badge)
             note.sound = payload.sound
+            note.category = payload.category
+            note.contentAvailable = payload.contentAvailable
             if @payloadFilter?
                 for key, val of payload.data
                     note.payload[key] = val if key in @payloadFilter

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dependencies":
     {
         "coffee-script": "~1.8.0",
-        "apn": "1.6.1",
+        "apn": "1.6.2",
         "c2dm": "1.2.1",
         "node-gcm": "0.9.12",
         "mpns": "2.1.0",

--- a/tests/payload.coffee
+++ b/tests/payload.coffee
@@ -8,7 +8,7 @@ describe 'Payload', ->
             (=> new Payload('var.test': 'value')).should.throw('Empty payload')
             (=> new Payload(sound: 'value')).should.throw('Empty payload')
             (=> new Payload(category: 'value')).should.throw('Empty payload')
-            (=> new Payload(contentAvalilable: 'value')).should.throw('Empty payload')
+            (=> new Payload(contentAvailable: 'value')).should.throw('Empty payload')
 
     describe 'with invalid key', =>
         it 'should throw an error', =>

--- a/tests/payload.coffee
+++ b/tests/payload.coffee
@@ -7,6 +7,8 @@ describe 'Payload', ->
             (=> new Payload({})).should.throw('Empty payload')
             (=> new Payload('var.test': 'value')).should.throw('Empty payload')
             (=> new Payload(sound: 'value')).should.throw('Empty payload')
+            (=> new Payload(category: 'value')).should.throw('Empty payload')
+            (=> new Payload(contentAvalilable: 'value')).should.throw('Empty payload')
 
     describe 'with invalid key', =>
         it 'should throw an error', =>


### PR DESCRIPTION
Added category and 'content-available' to payload.
These params are available for apns notification payload.