### PR TITLE
Automatically delete duplicate subscriptions

### DIFF
--- a/lib/pushservices/gcm.coffee
+++ b/lib/pushservices/gcm.coffee
@@ -54,6 +54,9 @@ class PushServiceGCM
     handleResult: (result, subscriber) ->
         if result.messageId or result.message_id
             if result.registration_id
+                # GCM sends registration_id if there is duplicate subscription with same device/app ID.
+                # Remove subscriber to avoid duplicate notifications. GCM does not send this to latest
+                # subscription so there is no race condition where both subscriptions will be deleted.
                 @logger?.warn("GCM Removing subscriber #{subscriber.id} of canonical #{result.canonical_id}")
                 subscriber.delete()
         else

--- a/lib/pushservices/gcm.coffee
+++ b/lib/pushservices/gcm.coffee
@@ -8,6 +8,7 @@ class PushServiceGCM
 
     constructor: (conf, @logger, tokenResolver) ->
         conf.concurrency ?= 10
+        conf.deleteDuplicatesAutomatically ?= false
         @driver = new gcm.Sender(conf.key)
         @multicastQueue = {}
 
@@ -54,11 +55,12 @@ class PushServiceGCM
     handleResult: (result, subscriber) ->
         if result.messageId or result.message_id
             if result.registration_id
-                # GCM sends registration_id if there is duplicate subscription with same device/app ID.
-                # Remove subscriber to avoid duplicate notifications. GCM does not send this to latest
-                # subscription so there is no race condition where both subscriptions will be deleted.
-                @logger?.warn("GCM Removing subscriber #{subscriber.id} of canonical #{result.canonical_id}")
-                subscriber.delete()
+                if @conf.deleteDuplicatesAutomatically
+                    # GCM sends registration_id if there is duplicate subscription with same device/app ID.
+                    # Remove subscriber to avoid duplicate notifications. GCM does not send this to latest
+                    # subscription so there is no race condition where both subscriptions will be deleted.
+                    @logger?.warn("GCM Removing subscriber #{subscriber.id} of canonical #{result.canonical_id}")
+                    subscriber.delete()
         else
             error = result.error or result.errorCode
             if error is "NotRegistered" or error is "InvalidRegistration"

--- a/lib/pushservices/gcm.coffee
+++ b/lib/pushservices/gcm.coffee
@@ -53,16 +53,16 @@ class PushServiceGCM
 
     handleResult: (result, subscriber) ->
         if result.messageId or result.message_id
-            # if result.canonicalRegistrationId
-                # TODO: update subscriber token
+            if result.registration_id
+                @logger?.warn("GCM Removing subscriber #{subscriber.id} of canonical #{result.canonical_id}")
+                subscriber.delete()
         else
             error = result.error or result.errorCode
             if error is "NotRegistered" or error is "InvalidRegistration"
-                @logger?.warn("GCM Automatic unregistration for subscriber #{subscriber.id}")
+                @logger?.warn("GCM Automatic unregistration for subscriber #{subscriber.id} due to #{error}")
                 subscriber.delete()
             else
                 @logger?.error("GCM Error: #{error}")
-
 
 
 exports.PushServiceGCM = PushServiceGCM

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -69,6 +69,10 @@ exports['gcm'] =
     enabled: yes
     class: require('./lib/pushservices/gcm').PushServiceGCM
     key: 'GCM API KEY HERE'
+    # If GCM reports another registration, automatically delete
+    # earlier one. Normally this is okay, but with multiple different
+    # push servers it might be necessary to disable this.
+    deleteDuplicatesAutomatically: yes
 
 # # Legacy Android Push Service
 # exports['c2dm'] =


### PR DESCRIPTION
GCM automatically detects duplicate subscriptions and sends registration ID for latest subscription. There is no need to update subscriber token, as there should be another subscription already. 

This functionality can be controlled with deleteDuplicatesAutomatically option (defaults to false to keep old functionality, sample setting is true, as it's usually sensible).

There might be reason not to automatically delete duplicates when running multiple different push servers for the same app. This is documented in settings-sample.coffee

Also, random error logging improvement.