### PR TITLE
Fix crash when registering subscriber

### DIFF
--- a/lib/subscriber.coffee
+++ b/lib/subscriber.coffee
@@ -123,9 +123,9 @@ class Subscriber
             cb(@info)
         else
             @redis.hgetall @key, (err, @info) =>
-                if info?.updated? # subscriber exists
+                if @info?.updated? # subscriber exists
                     # transform numeric value to number type
-                    for own key, value of info
+                    for own key, value of @info
                         num = parseInt(value)
                         @info[key] = if num + '' is value then num else value
                     cb(@info)


### PR DESCRIPTION
I try to register a new subscriber using the following command

````bash
$ curl -d proto=apns \
       -d token=FE66489F304DC75B8D6E8200DFF8A456E8DAEACEC428B427E9518741C92C6660 \
       -d lang=fr \
       -d badge=0 \
       -d category=show \
       -d contentAvailable=true \
       http://localhost/subscribers
````

This results in the following stack trace

````
/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:602
                throw err;
                      ^
TypeError: Cannot set property 'id' of null
  at /Users/andre/source/product-foundry/pushd/lib/api.coffee:20:21
  at /Users/andre/source/product-foundry/pushd/lib/subscriber.coffee:133:21
  at try_callback (/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:592:9)
  at RedisClient.return_reply (/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:685:13)
  at HiredisReplyParser.<anonymous> (/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:321:14)
  at HiredisReplyParser.emit (events.js:95:17)
  at HiredisReplyParser.execute (/Users/andre/source/product-foundry/pushd/node_modules/redis/lib/parser/hiredis.js:43:18)
  at RedisClient.on_data (/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:547:27)
  at Socket.<anonymous> (/Users/andre/source/product-foundry/pushd/node_modules/redis/index.js:102:14)
  at Socket.emit (events.js:95:17)
  at Socket.<anonymous> (_stream_readable.js:764:14)
  at Socket.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:426:10)
  at emitReadable (_stream_readable.js:422:5)
  at readableAddChunk (_stream_readable.js:165:9)
  at Socket.Readable.push (_stream_readable.js:127:10)
  at TCP.onread (net.js:528:21)
````

I use the following versions:
- Redis 2.8.18 (00000000/0) 64 bit
- CoffeeScript version 1.9.1

Reading the info property from the context in the pull request fixes the problem and gives the expected result.