### PR TITLE
Allow unicast events for a known subscriber id

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features
 - Server side message translation
 - Message template
 - Broadcast
+- Direct messages
 - GCM multicast messaging
 - Events statistics
 - Automatic failing subscriber unregistration
@@ -368,7 +369,7 @@ To test for the presence of a single subscription, perform a GET on the subscrip
     <
     < {"ignore_message":false}
 
-#### Bulk edit subcribers's Subscriptions
+#### Bulk edit subscribers's Subscriptions
 
 To set all subscriptions in one request, perform a POST with a JSON object on `/subscriber/SUBSCRIBER_ID/subscriptions` with event names as key and a dictionary of options as value or null.
 
@@ -384,9 +385,19 @@ To set all subscriptions in one request, perform a POST with a JSON object on `/
 
 ### Event Ingestion
 
-To generate notifications, your service must send events to pushd. The service doesn't have to know if a subscriber is subscribed to an event in order to send it, it just send all subscriptable events as they happen and pushd handles the rest.
+To generate notifications, your service must send events to pushd. The service doesn't have to know if a subscriber is subscribed to an event in order to send it, it just sends all subscriptable events as they happen and pushd handles the rest.
+
+It is also possible to ignore subscriptions and generate notifications directly using specialized event names.
 
 An event is some key/value pairs in a specific format sent to pushd either using HTTP POST or UDP datagrams.
+
+#### Event names
+
+The event name is commonly used to send notifications for registered subscriptions. There are two exceptions, in which case notifications can be sent without a subscription:
+
+- `broadcast` sends the notification to all subscribers
+- `unicast:SUBSCRIBER_ID` sends the notification to the subscriber with the specified id
+
 
 #### Event Message Format
 

--- a/lib/event.coffee
+++ b/lib/event.coffee
@@ -4,6 +4,7 @@ logger = require 'winston'
 class Event
     OPTION_IGNORE_MESSAGE: 1
     name_format: /^[a-zA-Z0-9@:._-]{1,100}$/
+    unicast_format: /^unicast:(.+)$/
 
     constructor: (@redis, @name) ->
         throw new Error("Missing redis connection") if not @redis?
@@ -28,9 +29,20 @@ class Event
                 else
                     cb(null)
 
+    unicastSubscriber: ->
+        Subscriber = require('./subscriber').Subscriber
+        if (matches = Event::unicast_format.exec @name)?
+            subscriberId = matches[1]
+            new Subscriber(@redis, subscriberId)
+        else
+            null
+
     exists: (cb) ->
         if @name is 'broadcast'
             cb(true)
+        else if (subscriber = @unicastSubscriber())?
+            subscriber.get (fields) =>
+                cb(fields?)
         else
             @redis.sismember "events", @name, (err, exists) =>
                 cb(exists)
@@ -38,15 +50,7 @@ class Event
     delete: (cb) ->
         logger.verbose "Deleting event #{@name}"
 
-        subscriberCount = 0
-        @forEachSubscribers (subscriber, subOptions, done) =>
-            # action
-            subscriber.removeSubscription(@, done)
-            subscriberCount += 1
-        , =>
-            # finished
-            logger.verbose "Unsubscribed #{subscriberCount} subscribers from #{@name}"
-    
+        performDelete = () =>
             @redis.multi()
                 # delete event's info hash
                 .del(@key)
@@ -54,6 +58,20 @@ class Event
                 .srem("events", @name)
                 .exec (err, results) ->
                     cb(results[1] > 0) if cb
+
+
+        if @unicastSubscriber()?
+            performDelete()
+        else
+            subscriberCount = 0
+            @forEachSubscribers (subscriber, subOptions, done) =>
+                # action
+                subscriber.removeSubscription(@, done)
+                subscriberCount += 1
+            , =>
+                # finished
+                logger.verbose "Unsubscribed #{subscriberCount} subscribers from #{@name}"
+                performDelete()
 
     log: (cb) ->
         @redis.multi()
@@ -64,41 +82,46 @@ class Event
             .exec =>
                 cb() if cb
 
-    # Performs an action on each subscriber subsribed to this event
+    # Performs an action on each subscriber subscribed to this event
     forEachSubscribers: (action, finished) ->
         Subscriber = require('./subscriber').Subscriber
-        if @name is 'broadcast'
-            # if event is broadcast, do not treat score as subscription option, ignore it
-            performAction = (subscriberId, subOptions) =>
-                return (done) =>
-                    action(new Subscriber(@redis, subscriberId), {}, done)
-        else
-            performAction = (subscriberId, subOptions) =>
-                options = {ignore_message: (subOptions & Event::OPTION_IGNORE_MESSAGE) isnt 0}
-                return (done) =>
-                    action(new Subscriber(@redis, subscriberId), options, done)
 
-        subscribersKey = if @name is 'broadcast' then 'subscribers' else "#{@key}:subs"
-        page = 0
-        perPage = 100
-        total = 0
-        async.whilst =>
-            # test if we got less items than requested during last request
-            # if so, we reached to end of the list
-            return page * perPage == total
-        , (done) =>
-            # treat subscribers by packs of 100 with async to prevent from blocking the event loop
-            # for too long on large subscribers lists
-            @redis.zrange subscribersKey, (page * perPage), (page * perPage + perPage - 1), 'WITHSCORES', (err, subscriberIdsAndOptions) =>
-                tasks = []
-                for id, i in subscriberIdsAndOptions by 2
-                    tasks.push performAction(id, subscriberIdsAndOptions[i + 1])
-                async.series tasks, =>
-                    total += subscriberIdsAndOptions.length / 2
-                    done()
-            page++
-        , =>
-            # all done
-            finished(total) if finished
+        if (subscriber = @unicastSubscriber())?
+            # if event is unicast, do not treat score as subscription option, ignore it
+            action(subscriber, {}, -> finished(1) if finished)
+        else
+            if @name is 'broadcast'
+                # if event is broadcast, do not treat score as subscription option, ignore it
+                performAction = (subscriberId, subOptions) =>
+                    return (done) =>
+                        action(new Subscriber(@redis, subscriberId), {}, (done))
+            else
+                performAction = (subscriberId, subOptions) =>
+                    options = {ignore_message: (subOptions & Event::OPTION_IGNORE_MESSAGE) isnt 0}
+                    return (done) =>
+                        action(new Subscriber(@redis, subscriberId), options, done)
+
+            subscribersKey = if @name is 'broadcast' then 'subscribers' else "#{@key}:subs"
+            page = 0
+            perPage = 100
+            total = 0
+            async.whilst =>
+                # test if we got less items than requested during last request
+                # if so, we reached to end of the list
+                return page * perPage == total
+            , (done) =>
+                # treat subscribers by packs of 100 with async to prevent from blocking the event loop
+                # for too long on large subscribers lists
+                @redis.zrange subscribersKey, (page * perPage), (page * perPage + perPage - 1), 'WITHSCORES', (err, subscriberIdsAndOptions) =>
+                    tasks = []
+                    for id, i in subscriberIdsAndOptions by 2
+                        tasks.push performAction(id, subscriberIdsAndOptions[i + 1])
+                    async.series tasks, =>
+                        total += subscriberIdsAndOptions.length / 2
+                        done()
+                page++
+            , =>
+                # all done
+                finished(total) if finished
 
 exports.Event = Event

--- a/lib/event.coffee
+++ b/lib/event.coffee
@@ -1,4 +1,5 @@
 async = require 'async'
+Subscriber = require('./subscriber').Subscriber
 logger = require 'winston'
 
 class Event
@@ -30,7 +31,6 @@ class Event
                     cb(null)
 
     unicastSubscriber: ->
-        Subscriber = require('./subscriber').Subscriber
         if (matches = Event::unicast_format.exec @name)?
             subscriberId = matches[1]
             new Subscriber(@redis, subscriberId)
@@ -85,7 +85,6 @@ class Event
     # Performs an action on each subscriber subscribed to this event
     forEachSubscribers: (action, finished) ->
         Subscriber = require('./subscriber').Subscriber
-
         if (subscriber = @unicastSubscriber())?
             # if event is unicast, do not treat score as subscription option, ignore it
             action(subscriber, {}, -> finished(1) if finished)

--- a/lib/subscriber.coffee
+++ b/lib/subscriber.coffee
@@ -237,7 +237,7 @@ class Subscriber
 
     removeSubscription: (event, cb) ->
         @redis.multi()
-            # check subscriber existance
+            # check subscriber existence
             .zscore("subscribers", @id)
             # remove event from subscriber's subscriptions list
             .zrem("#{@key}:evts", event.name)

--- a/tests/event.coffee
+++ b/tests/event.coffee
@@ -123,6 +123,7 @@ describe 'Event', ->
                 done()
 
         it 'should push to one subscriber', (done) =>
+            PushServiceFake::total = 0
             createSubscriber @redis, (@subscriber) =>
                 @subscriber.addSubscription @event, 0, (added) =>
                     added.should.be.true
@@ -131,6 +132,39 @@ describe 'Event', ->
                         PushServiceFake::total.should.equal 1
                         total.should.equal 1
                         done()
+
+        it 'should push unicast event to subscriber', (done) =>
+            PushServiceFake::total = 0
+
+            createSubscriber @redis, (@subscriber) =>
+                unicastEvent = new Event(@redis, "unicast:#{@subscriber.id}")
+
+                @publisher.publish unicastEvent, {msg: 'test'}, (total) =>
+                    PushServiceFake::total.should.equal 1
+                    total.should.equal 1
+                    unicastEvent.delete ->
+                        done()
+
+    describe 'unicastSubscriber', =>
+        it 'should provide subscriber for unicast event', (doneAll) =>
+            totalSubscribers = 410
+            subscribers = []
+            async.whilst =>
+                subscribers.length < totalSubscribers
+            , (doneCreatingSubscriber) =>
+                createSubscriber @redis, (subscriber) =>
+                    subscribers.push subscriber
+                    event = new Event(@redis, "unicast:#{subscriber.id}")
+                    event.unicastSubscriber().id.should.equal subscriber.id
+                    doneCreatingSubscriber()
+            , =>
+                async.whilst =>
+                    subscribers.length > 0
+                , (doneCleaningSubscribers) =>
+                    subscribers.pop().delete =>
+                        doneCleaningSubscribers()
+                , =>
+                    doneAll()
 
     describe 'stats', =>
         it 'should increment increment total field on new subscription', (done) =>


### PR DESCRIPTION
Notify subscribers directly using the event name format `unicast:[subscriber.id]`

This removes the need to create a special subscription for this scenario.

Fixes https://github.com/rs/pushd/issues/78

