### PR TITLE
Workaround for nodejs 0.12 which defaults to ipv6 addresses and breaks netmask module.

### DIFF
--- a/pushd.coffee
+++ b/pushd.coffee
@@ -128,9 +128,13 @@ if eventSourceEnabled
     require('./lib/eventsource').setup(app, authorize, eventPublisher)
 
 port = settings?.server?.tcp_port ? 80
-app.listen port
-logger.info "Listening on tcp port #{port}"
-
+listen_ip = settings?.server?.listen_ip
+if listen_ip
+    app.listen port, listen_ip
+    logger.info "Listening on ip address #{listen_ip} and tcp port #{port}"
+else
+    app.listen port
+    logger.info "Listening on tcp port #{port}"
 
 # UDP Event API
 udpApi = dgram.createSocket("udp4")

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -3,6 +3,7 @@ exports.server =
     redis_host: 'localhost'
     # redis_socket: '/var/run/redis/redis.sock'
     # redis_auth: 'password'
+    # listen_ip: '10.0.1.2'
     tcp_port: 80
     udp_port: 80
     access_log: yes
@@ -118,7 +119,7 @@ exports['mpns-raw'] =
     type: 'raw'
 
 # Transports: Console, File, Http
-# 
+#
 # Common options:
 # level:
 #   error: log errors only


### PR DESCRIPTION
This is done by setting 'listen_ip' to an ipv4 address to listen to.
