### PR TITLE
Remove duplicated subscriber for one device

### DIFF
--- a/lib/pushservices/gcm.coffee
+++ b/lib/pushservices/gcm.coffee
@@ -52,7 +52,10 @@ class PushServiceGCM
                 @handleResult multicastResult, message.subscribers[0]
 
     handleResult: (result, subscriber) ->
-        if result.messageId or result.message_id
+        if result.registration_id?
+            # Remove duplicated subscriber for one device
+            subscriber.delete() if result.registration_id isnt subscriber.info.token
+        else if result.messageId or result.message_id
             # if result.canonicalRegistrationId
                 # TODO: update subscriber token
         else


### PR DESCRIPTION
After installation multiple times the same application, pushd has registered multiple token to the same device. In the result is multiple the same messages from GCM for one unique device.

To prevent this in the future removes all subscriber whose token has been changed.