### PR TITLE
Badge count change

### DIFF
--- a/lib/payload.coffee
+++ b/lib/payload.coffee
@@ -26,6 +26,7 @@ class Payload
                 when 'msg' then @msg.default = value
                 when 'sound' then @sound = value
                 when 'incrementBadge' then @incrementBadge = value != 'false'
+                when 'badge' then @badge = value
                 when 'category' then @category = value
                 when 'contentAvailable' then @contentAvailable = value != 'false'
                 else

--- a/lib/pushservices/apns.coffee
+++ b/lib/pushservices/apns.coffee
@@ -40,7 +40,7 @@ class PushServiceAPNS
             if subOptions?.ignore_message isnt true and alert = payload.localizedMessage(info.lang)
                 note.alert = alert
 
-            badge = parseInt(info.badge)
+            badge = parseInt(payload.badge || info.badge)
             if payload.incrementBadge
                 badge += 1
             


### PR DESCRIPTION
    Allow events to include a badge count which overrides the internal badge counting

Our use case might be a bit atypical in that we need to pass a badge count in the payload. Is this something that would be useful as part of the main project?