### PR TITLE
Validate if event exists when posting a message

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -159,8 +159,13 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
 
     # Publish an event
     app.post '/event/:event_id', authorize('publish'), (req, res) ->
-        res.send 204
-        eventPublisher.publish(req.event, req.body)
+        req.event.exists (exists) ->
+            if not exists
+                logger.error "No event #{req.event.name}"
+            else
+                eventPublisher.publish(req.event, req.body)
+
+            res.send if exists then 204 else 404
 
     # Delete an event
     app.delete '/event/:event_id', authorize('publish'), (req, res) ->


### PR DESCRIPTION
When sending events, return 404 Not Found rather than 204 No Content in case the event does not exist. This prevents errors in event names or subscriber IDs from going unnoticed when using the pushd server.

- broadcast: always succeeds
- unicast:subscriber_id succeeds if subscriber exists
- all other cases succeed only if the event is known

Fixes #131 