### PR TITLE
Allow to select redis database number in settings

### DIFF
--- a/pushd.coffee
+++ b/pushd.coffee
@@ -16,6 +16,8 @@ if settings.server.redis_socket?
     redis = require('redis').createClient(settings.server.redis_socket)
 else if settings.server.redis_port? or settings.server.redis_host?
     redis = require('redis').createClient(settings.server.redis_port, settings.server.redis_host)
+if settings.server.redis_db_number?
+    redis.select(settings.server.redis_db_number)
 
 if settings.logging?
     logger.remove(logger.transports.Console)

--- a/settings-sample.coffee
+++ b/settings-sample.coffee
@@ -3,6 +3,7 @@ exports.server =
     redis_host: 'localhost'
     # redis_socket: '/var/run/redis/redis.sock'
     # redis_auth: 'password'
+    # redis_db_number: 2
     # listen_ip: '10.0.1.2'
     tcp_port: 80
     udp_port: 80


### PR DESCRIPTION
Allow to select redis db index. 
Prevent name collisions in db keys when used many instances of pushd at the one server