### PR TITLE
Fixes #60 -- broken subscriber deletion

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -141,12 +141,13 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
 
     # Unsubscribe a subscriber from an event
     app.delete '/subscriber/:subscriber_id/subscriptions/:event_id', authorize('register'), (req, res) ->
-        req.subscriber.removeSubscription req.event, (deleted) ->
-            if not deleted?
-                logger.error "No subscriber #{req.subscriber.id}"
-            else if not deleted
-                logger.error "Subscriber #{req.subscriber.id} was not subscribed to #{req.event.name}"
-            res.send if deleted then 204 else 404
+        req.subscriber.removeSubscription req.event, (errorDeleting) ->
+            if errorDeleting?
+                logger.error "No subscriber #{req.subscriber.id} or not subscribed to #{req.event.name}"
+
+            # TODO: add the check for empty events and the requisite event.delete() call here.
+
+            res.send if errorDeleting then 404 else 204
 
     # Event stats
     app.get '/event/:event_id', authorize('register'), (req, res) ->
@@ -171,10 +172,10 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
                 res.send 204
             else
                 res.send 404
+
     # Server status
     app.get '/status', authorize('register'), (req, res) ->
         if checkStatus()
             res.send 204
         else
             res.send 503
-    

--- a/lib/event.coffee
+++ b/lib/event.coffee
@@ -63,14 +63,13 @@ class Event
         if @unicastSubscriber()?
             performDelete()
         else
-            subscriberCount = 0
-            @forEachSubscribers (subscriber, subOptions, done) =>
+            @forEachSubscribers (subscriber, subOptions, doneCb) =>
                 # action
-                subscriber.removeSubscription(@, done)
-                subscriberCount += 1
-            , =>
+                subscriber.removeSubscription(@, doneCb)
+                # subscriberCount += 1
+            , (totalSubscribers)=>
                 # finished
-                logger.verbose "Unsubscribed #{subscriberCount} subscribers from #{@name}"
+                logger.verbose "Unsubscribed #{totalSubscribers} subscribers from #{@name}"
                 performDelete()
 
     log: (cb) ->
@@ -92,13 +91,13 @@ class Event
             if @name is 'broadcast'
                 # if event is broadcast, do not treat score as subscription option, ignore it
                 performAction = (subscriberId, subOptions) =>
-                    return (done) =>
-                        action(new Subscriber(@redis, subscriberId), {}, (done))
+                    return (doneCb) =>
+                        action(new Subscriber(@redis, subscriberId), {}, (doneCb))
             else
                 performAction = (subscriberId, subOptions) =>
                     options = {ignore_message: (subOptions & Event::OPTION_IGNORE_MESSAGE) isnt 0}
-                    return (done) =>
-                        action(new Subscriber(@redis, subscriberId), options, done)
+                    return (doneCb) =>
+                        action(new Subscriber(@redis, subscriberId), options, doneCb)
 
             subscribersKey = if @name is 'broadcast' then 'subscribers' else "#{@key}:subs"
             page = 0
@@ -107,18 +106,18 @@ class Event
             async.whilst =>
                 # test if we got less items than requested during last request
                 # if so, we reached to end of the list
-                return page * perPage == total
-            , (done) =>
+                return ( page * perPage ) == total
+            , (chunkDone) =>
                 # treat subscribers by packs of 100 with async to prevent from blocking the event loop
                 # for too long on large subscribers lists
-                @redis.zrange subscribersKey, (page * perPage), (page * perPage + perPage - 1), 'WITHSCORES', (err, subscriberIdsAndOptions) =>
+                @redis.zrange subscribersKey, 0, 99, 'WITHSCORES', (err, subscriberIdsAndOptions) =>
                     tasks = []
                     for id, i in subscriberIdsAndOptions by 2
                         tasks.push performAction(id, subscriberIdsAndOptions[i + 1])
                     async.series tasks, =>
                         total += subscriberIdsAndOptions.length / 2
-                        done()
-                page++
+                        page++
+                        chunkDone()
             , =>
                 # all done
                 finished(total) if finished

--- a/lib/subscriber.coffee
+++ b/lib/subscriber.coffee
@@ -246,17 +246,23 @@ class Subscriber
             # check if the subscriber list still exist after previous zrem
             .zcard("#{event.key}:subs")
             .exec (err, results) =>
-                if results[3] is 0
-                    # The event subscriber list is now empty, clean it
-                    event.delete() # TOFIX possible race condition
+
+                if err
+                  logger.verbose "Error removing Subscription: #{err}"
+                  cb(err)
+
+                # if results[3] is 0
+                #     # The event subscriber list is now empty, clean it
+                #     event.delete() # TOFIX possible race condition
 
                 if results[0]? # subscriber exists?
                     wasRemoved = results[1] is 1 # true if removed, false if wasn't subscribed
                     if wasRemoved
                         logger.verbose "Subscriber #{@id} unregistered from event #{event.name}"
-                    cb(wasRemoved) if cb
+                    cb(null) if cb
                 else
-                    cb(null) if cb # null if subscriber doesn't exist
+                    logger.verbose "Subscriber #{@id} doesn't exist"
+                    cb("Not exists") if cb # null if subscriber doesn't exist
 
 
 exports.Subscriber = Subscriber

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "express": "~3.20.2",
         "body-parser": "~1.9.0",
         "hiredis": "~0.1.17",
-        "redis": "~0.12.1",
+        "redis": "~1.0.0",
         "netmask": "~1.0.4",
         "winston": "~0.7.3",
         "wns": "git://github.com/futurice/wns.git#28bfe39a3be8c64f3d72b7c7a5cac77c049b137a"


### PR DESCRIPTION
This fixes #60. In summary:

1. The callback in subscriber.coffee is the opposite to what it should be. `async.serial` expects `null` as the first argument of the 'task' functions in order to proceed with the remaining tasks. The code returned `@id` on success, hence only the first subscriber of each 'page' was processed.

2. When deleting in chunks from a data source the code should not increment the deletion 'pointer' by page * perPage offset as the code did, but a) either delete records from the end and 'decrement' the pointer, or b) delete from 0 up to 100 (or as much as is left, whichever applies). I implemented (b) in this case, as it was shorter and it seems to work well.

3. (1) requires some additional changes in api.coffee too. This kind of messes up error reporting, but I guess you could improve this if you wanted -- say, by providing another layer of encapsulation and a richer signature to the callbacks.

4. I also bumped the node-redis dependency to ~1.0.0. I guess we could, ideally, use newer versions of some of the dependencies that remain backwards compatible with this codebase.

It seems to work well, but I haven't tested the code much. Also, note that I haven't looked at/modified the tests.