### PR TITLE
Updating hiredis package to version 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "async": "~0.2.10",
         "express": "~3.20.2",
         "body-parser": "~1.9.0",
-        "hiredis": "~0.1.17",
+        "hiredis": "~0.4.1",
         "redis": "~0.12.1",
         "netmask": "~1.0.4",
         "winston": "~0.7.3",


### PR DESCRIPTION
Hiredis frequently fails to install for me when running npm install.  I updated the hiredis package to the newest release to fix the issue as per:

https://github.com/redis/hiredis-node/issues/94