### PR TITLE
Fixes subscriber deletion. Includes updated tests. Updates redis to 1.0.0

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -141,12 +141,13 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
 
     # Unsubscribe a subscriber from an event
     app.delete '/subscriber/:subscriber_id/subscriptions/:event_id', authorize('register'), (req, res) ->
-        req.subscriber.removeSubscription req.event, (deleted) ->
-            if not deleted?
-                logger.error "No subscriber #{req.subscriber.id}"
-            else if not deleted
-                logger.error "Subscriber #{req.subscriber.id} was not subscribed to #{req.event.name}"
-            res.send if deleted then 204 else 404
+        req.subscriber.removeSubscription req.event, (errorDeleting) ->
+            if errorDeleting?
+                logger.error "No subscriber #{req.subscriber.id} or not subscribed to #{req.event.name}"
+
+            # TODO: add the check for empty events and the requisite event.delete() call here.
+
+            res.send if errorDeleting then 404 else 204
 
     # Event stats
     app.get '/event/:event_id', authorize('register'), (req, res) ->
@@ -171,10 +172,10 @@ exports.setupRestApi = (app, createSubscriber, getEventFromId, authorize, testSu
                 res.send 204
             else
                 res.send 404
+
     # Server status
     app.get '/status', authorize('register'), (req, res) ->
         if checkStatus()
             res.send 204
         else
             res.send 503
-    

--- a/lib/subscriber.coffee
+++ b/lib/subscriber.coffee
@@ -246,17 +246,23 @@ class Subscriber
             # check if the subscriber list still exist after previous zrem
             .zcard("#{event.key}:subs")
             .exec (err, results) =>
-                if results[3] is 0
-                    # The event subscriber list is now empty, clean it
-                    event.delete() # TOFIX possible race condition
+
+                if err
+                  logger.verbose "Error removing Subscription: #{err}"
+                  cb(err)
+
+                # if results[3] is 0
+                #     # The event subscriber list is now empty, clean it
+                #     event.delete() # TOFIX possible race condition
 
                 if results[0]? # subscriber exists?
                     wasRemoved = results[1] is 1 # true if removed, false if wasn't subscribed
                     if wasRemoved
                         logger.verbose "Subscriber #{@id} unregistered from event #{event.name}"
-                    cb(wasRemoved) if cb
+                    cb(null) if cb
                 else
-                    cb(null) if cb # null if subscriber doesn't exist
+                    logger.verbose "Subscriber #{@id} doesn't exist"
+                    cb("Not exists") if cb # null if subscriber doesn't exist
 
 
 exports.Subscriber = Subscriber

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "express": "~3.20.2",
         "body-parser": "~1.9.0",
         "hiredis": "~0.4.1",
-        "redis": "~0.12.1",
+        "redis": "~1.0.0",
         "netmask": "~1.0.4",
         "winston": "~0.7.3",
         "wns": "git://github.com/futurice/wns.git#28bfe39a3be8c64f3d72b7c7a5cac77c049b137a"

--- a/tests/event.coffee
+++ b/tests/event.coffee
@@ -69,6 +69,7 @@ describe 'Event', ->
                 unhandledSubscribers = {}
                 for subscriber in subscribers
                     unhandledSubscribers[subscriber.id] = true
+
                 @event.forEachSubscribers (subscriber, subOptions, done) =>
                     unhandledSubscribers[subscriber.id].should.be.true
                     delete unhandledSubscribers[subscriber.id]

--- a/tests/subscriber.coffee
+++ b/tests/subscriber.coffee
@@ -178,20 +178,20 @@ describe 'Subscriber', ->
 
         it 'should not remove subscription on an unexisting subscription', (done) =>
             subscriber = new Subscriber(@subscriber.redis, 'invalidid')
-            subscriber.removeSubscription @testEvent, (removed) =>
-                should.exist(removed)
+            subscriber.removeSubscription @testEvent, (errDeleting) =>
+                should.exist(errDeleting)
                 done()
         it 'should not remove an unsubscribed event', (done) =>
-            @subscriber.removeSubscription @testEvent, (removed) =>
-                should.not.exist(removed)
+            @subscriber.removeSubscription @testEvent, (errDeleting) =>
+                should.not.exist(errDeleting)
                 done()
         it 'should remove an subscribed event correctly', (done) =>
             @subscriber.addSubscription @testEvent, 0, (added) =>
                 added.should.be.true
-                @subscriber.removeSubscription @testEvent, (removed) =>
-                    should.not.exist(removed)
+                @subscriber.removeSubscription @testEvent, (errDeleting) =>
+                    should.not.exist(errDeleting)
                     done()
         it 'should not remove an already removed subscription', (done) =>
-            @subscriber.removeSubscription @testEvent, (removed) =>
-                should.not.exist(removed)
+            @subscriber.removeSubscription @testEvent, (errDeleting) =>
+                should.not.exist(errDeleting)
                 done()

--- a/tests/subscriber.coffee
+++ b/tests/subscriber.coffee
@@ -179,19 +179,19 @@ describe 'Subscriber', ->
         it 'should not remove subscription on an unexisting subscription', (done) =>
             subscriber = new Subscriber(@subscriber.redis, 'invalidid')
             subscriber.removeSubscription @testEvent, (removed) =>
-                should.not.exist removed
+                should.exist(removed)
                 done()
         it 'should not remove an unsubscribed event', (done) =>
             @subscriber.removeSubscription @testEvent, (removed) =>
-                removed.should.be.false
+                should.not.exist(removed)
                 done()
         it 'should remove an subscribed event correctly', (done) =>
             @subscriber.addSubscription @testEvent, 0, (added) =>
                 added.should.be.true
                 @subscriber.removeSubscription @testEvent, (removed) =>
-                    removed.should.be.true
+                    should.not.exist(removed)
                     done()
         it 'should not remove an already removed subscription', (done) =>
             @subscriber.removeSubscription @testEvent, (removed) =>
-                removed.should.be.false
+                should.not.exist(removed)
                 done()


### PR DESCRIPTION
This fixes #60 (properly this time)

The callback in subscriber.coffee is the opposite to what it should be. async.serial expects null as the first argument of the 'task' functions in order to proceed with the remaining tasks. The code returned `@id` on success, hence only the first subscriber of each 'page' was processed.

When deleting in chunks from a data source the code should not increment the deletion 'pointer' by page \* perPage offset as the code did, but a) either delete records from the end and 'decrement' the pointer, or b) delete from 0 up to 100 (or as much as is left, whichever applies). I implemented (a) in this case, as the iterator is also used for accessing the subscriber objects and (b) is not suited to both access and removal of elements.

(1) requires some additional changes in api.coffee too. This kind of messes up error reporting, but I guess you could improve this if you wanted – In general the change to the callback parameter is inconsistent – then again, the original code was consistent, but broken. This should probably be revised say, by providing another layer of encapsulation and a richer signature to the callbacks so that they are both consistent and conform to `async.serial` requirements.

I also bumped the node-redis dependency to ~1.0.0. As a sidenote, I think we could use newer versions of some of the dependencies that are known to be backwards compatible with this codebase.

I haven't tested this much, beyond some rudimentary testing on a staging box. All tests do run successfully though.
