### PR TITLE
Use HTTPS for futurice/wns git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "redis": "~0.12.1",
         "netmask": "~1.0.4",
         "winston": "~0.7.3",
-        "wns": "git://github.com/futurice/wns.git#28bfe39a3be8c64f3d72b7c7a5cac77c049b137a"
+        "wns": "git+https://github.com/futurice/wns.git#28bfe39a3be8c64f3d72b7c7a5cac77c049b137a"
     },
     "devDependencies":
     {


### PR DESCRIPTION
On certain machines npm install would fail with a timeout when attempting to connect to the futurice/wns git repo using SSH.  This modification allows the use of HTTPS which worked reliably on all machines.
